### PR TITLE
Always initialize connection of singleton

### DIFF
--- a/closql.el
+++ b/closql.el
@@ -312,7 +312,8 @@
                   (connection-class (or connection-class
                                         (emacsql-sqlite-default-connection)))
                   (conn (make-instance connection-class :file file))
-                  (db (make-instance class :connection conn)))
+                  (db (make-instance class))) ; ignores slot arguments
+             (oset db connection conn)
              (when (and (slot-boundp conn 'handle)
                         (processp (oref conn handle)))
                (set-process-query-on-exit-flag (oref conn handle) nil))


### PR DESCRIPTION
Hi Jonas,

today I saw you pinged me to update closql in one of my packages. My Github notifications are a mess, and I did not see that. I just started looking into this and stumbled upon the following issue:

When re-connecting to a previously closed database, the connection fails.

```
(emacsql-close (closql-db 'paimon-test-database))
(closql-db 'paimon-test-database)
```

```
Debugger entered--Lisp error: (cl-no-applicable-method emacsql nil [:select name :from sqlite-master :where (and (= type 'table) (not-like name "sqlite_%")) :order-by [(asc name)]])
```

I believe this is because the call to `(make-instance class
:connection conn)` does not set the connection slot of the already
existing singleton class. Setting the slot with `(oset db connection
conn)` seems to solve the issue.